### PR TITLE
Partially disable Rails/ReflectionClassName cop

### DIFF
--- a/app/models/spree/customer_image.rb
+++ b/app/models/spree/customer_image.rb
@@ -6,9 +6,11 @@ module Spree
       super + column_names
     end
 
+    # rubocop:disable Rails/ReflectionClassName
     belongs_to :product, class_name: 'Spree::Product', inverse_of: :customer_images, foreign_key: :spree_product_id, touch: true
     belongs_to :user, class_name: Spree.user_class.name, inverse_of: :customer_images, foreign_key: :spree_user_id, touch: true
     has_one :image, class_name: SolidusCustomerImages::Config.image_class_name, as: :viewable, dependent: :destroy
+    # rubocop:enable Rails/ReflectionClassName
 
     scope :approved, -> { where approved: true }
     scope :rejected, -> { where approved: false }


### PR DESCRIPTION
Cop was making CI fail and any efforts to fix the offenses is an endless cycle, as:

* Using `#to_s` doesn't really fix anything
* Using string interpolation does not fix the offenses either and Rubocop suggest using `#to_s`

I thought about disabling Rubocop entirely but I feel, for the sake of keeping our code clean and tidy, this is a better approach.